### PR TITLE
Fixed close() exception when using new Apache libraries

### DIFF
--- a/java-channels-api/pom.xml
+++ b/java-channels-api/pom.xml
@@ -20,17 +20,17 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.1</version>
+      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.1.2</version>
+      <version>4.3.2</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>20030203.000129</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/java-channels-api/src/main/java/edu/gvsu/cis/masl/channelAPI/ChannelAPI.java
+++ b/java-channels-api/src/main/java/edu/gvsu/cis/masl/channelAPI/ChannelAPI.java
@@ -24,7 +24,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -46,7 +46,7 @@ public class ChannelAPI {
     private ChannelService channelListener = new ChannelListener();
     private ReadyState readyState = ReadyState.CLOSED;
     private Integer TIMEOUT_MS = 500;
-    private HttpClient httpClient = new DefaultHttpClient();
+    private HttpClient httpClient = HttpClientBuilder.create().build();
     private Thread thPoll = null;
     
     /**
@@ -113,7 +113,7 @@ public class ChannelAPI {
      */
     private String createChannel(String key) throws IOException, ClientProtocolException{
     	String token = "";
-		HttpClient staticClient = new DefaultHttpClient();
+		HttpClient staticClient = HttpClientBuilder.create().build();
 		HttpGet httpGet = new HttpGet(BASE_URL + "/token?c=" + key);
 		try{
 			XHR xhr = new XHR(staticClient.execute(httpGet));
@@ -821,7 +821,7 @@ public class ChannelAPI {
      * @throws IOException
      */
     private XHR sendPost(String url, List<NameValuePair> params) throws IOException {
-    	HttpClient sendClient = new DefaultHttpClient();
+    	HttpClient sendClient = HttpClientBuilder.create().build();
     	UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, "UTF-8");
         HttpPost httpPost = new HttpPost(url);
         httpPost.setEntity(entity);


### PR DESCRIPTION
**Problem**
I was using the 'latest' Apache client for my application. Using this version threw an IllegalStateException whenever I tried to close the connection to a GAE server (not development).

**Exception Message**
Invalid use of BasicClientConnManager: connection still allocated.

**Solution**
I updated the library dependencies and migrated to use HttpClientBuilder to create a default http client instead of the now deprecated DefaultHttpClient.

close() doesn't throw an exception anymore.
